### PR TITLE
provider: add MiniMax-M3 model and Chat Completions compatible endpoints

### DIFF
--- a/src-tauri/providers/minimax-openai.yaml
+++ b/src-tauri/providers/minimax-openai.yaml
@@ -1,0 +1,59 @@
+# MiniMax Chat Completions 兼容端点 (OpenAI /v1/chat/completions 协议家族).
+# 与 minimax.yaml (Anthropic /v1/messages 透传) 并列, 共享同一 API key,
+# 区别在 auth_type=openai_chat_completions_api_key, 走 cc-router 的
+# Anthropic Messages <-> Chat Completions 协议翻译分支.
+#
+# 官方文档 (核对 2026-07):
+#   - Chat Completions: https://platform.minimax.io/docs/api-reference/chat-completion
+#   - 鉴权: Authorization: Bearer <MINIMAX_API_KEY>
+#   - 国际版 base: https://api.minimax.io/v1  国内版 base: https://api.minimaxi.com/v1
+#   - MiniMax 未提供公开 /models 接口, 只能手动输入模型 (与 anthropic 兼容端点侧一致).
+
+id: minimax_openai
+display_name: "MiniMax (Chat Completions)"
+icon: minimax
+category: first_party
+description: "MiniMax Chat Completions 兼容端点（MiniMax-M3 / M2 系列）"
+homepage: "https://platform.minimax.io"
+docs_url: "https://platform.minimax.io/docs"
+api_key_url: "https://platform.minimax.io/user-center/basic-information/interface-key"
+
+compatibility: untested
+compatibility_notes: 
+
+endpoints:
+  - id: global_chat_completions
+    label: "国际版 · Chat Completions 按量付费 API"
+    description: "api.minimax.io，按 token 计费"
+    base_url: "https://api.minimax.io/v1"
+    messages_path: "/chat/completions"
+    region: global
+    billing: pay_as_you_go
+
+  - id: china_chat_completions
+    label: "国内版 · Chat Completions 按量付费 API"
+    description: "api.minimaxi.com，国内加速访问"
+    base_url: "https://api.minimaxi.com/v1"
+    messages_path: "/chat/completions"
+    region: china
+    billing: pay_as_you_go
+
+default_endpoint: global_chat_completions
+
+auth:
+  type: openai_chat_completions_api_key
+  header_name: "Authorization"
+  header_format: bearer
+
+required_headers: {}
+forward_headers: []
+
+model_discovery:
+  # MiniMax 未提供公开 /models 接口, 只能手动输入 (与 anthropic 兼容端点侧一致)
+  enabled: false
+  path: "/v1/models"
+  cache_ttl_hours: 24
+  # 来源: https://platform.minimax.io/docs/guides/models-intro (2026-07 核对)
+  example_models:
+    - "MiniMax-M3"
+    - "MiniMax-M2.7"

--- a/src-tauri/providers/minimax.yaml
+++ b/src-tauri/providers/minimax.yaml
@@ -2,7 +2,7 @@ id: minimax
 display_name: "MiniMax"
 icon: minimax
 category: first_party
-description: "MiniMax M2 系列模型"
+description: "MiniMax M3 / M2 系列模型"
 homepage: "https://platform.minimax.io"
 docs_url: "https://platform.minimax.io/docs"
 api_key_url: "https://platform.minimax.io/user-center/basic-information/interface-key"
@@ -60,8 +60,9 @@ model_discovery:
   enabled: false
   path: "/v1/models"
   cache_ttl_hours: 24
-  # 来源: https://platform.minimax.io/docs/guides/models-intro (2026-04 核对)
+  # 来源: https://platform.minimax.io/docs/guides/models-intro (2026-07 核对)
   example_models:
+    - "MiniMax-M3"
     - "MiniMax-M2.7"
     - "MiniMax-M2.7-highspeed"
     - "MiniMax-M2.5"


### PR DESCRIPTION
Reason: provider-add — add MiniMax-M3 model metadata and global/CN Chat Completions compatible endpoints.

## Changes

- `src-tauri/providers/minimax.yaml`: register `MiniMax-M3` at the top of `example_models` (alongside the existing `MiniMax-M2.7`), refresh the description to mention the M3 / M2 series, and update the docs check note date.
- `src-tauri/providers/minimax-openai.yaml`: new built-in provider entry for the MiniMax Chat Completions compatible endpoints. It declares `auth.type: openai_chat_completions_api_key` so requests are routed through the Anthropic Messages <-> Chat Completions translation branch, with two regional pay-as-you-go endpoints:
  - `global_chat_completions` -> `https://api.minimax.io/v1/chat/completions`
  - `china_chat_completions` -> `https://api.minimaxi.com/v1/chat/completions`
  Both reuse the existing `minimax` brand icon and the same bearer API key. `example_models` lists `MiniMax-M3` and `MiniMax-M2.7`.

The pre-existing `minimax.yaml` already covers the Anthropic-compatible (`/v1/messages`) side for both regions; this change adds the missing Chat Completions compatible side and the M3 model metadata, keeping the two protocol families as separate providers (matching how the loader dispatches on `auth_type`).

## Checks

- Validated both YAML files parse and conform to `src-tauri/providers/_schema.json` (Draft-07) using ajv; verified the joined `base_url + messages_path` resolves to the documented Chat Completions URLs for each region.
- Secret scan over the diff: clean.
