### PR TITLE
Refresh MiniMax model and endpoint metadata

### DIFF
--- a/src-tauri/providers/_schema.json
+++ b/src-tauri/providers/_schema.json
@@ -60,6 +60,41 @@
         "example_models": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "model_metadata": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["model_id", "context_window", "pricing_usd_per_million_tokens", "input_modalities", "thinking"],
+            "additionalProperties": false,
+            "properties": {
+              "model_id": { "type": "string" },
+              "context_window": { "type": "integer", "minimum": 1 },
+              "pricing_usd_per_million_tokens": {
+                "type": "object",
+                "required": ["input", "output", "cache_read", "cache_write"],
+                "additionalProperties": false,
+                "properties": {
+                  "input": { "type": "number", "minimum": 0 },
+                  "output": { "type": "number", "minimum": 0 },
+                  "cache_read": { "type": ["number", "null"], "minimum": 0 },
+                  "cache_write": { "type": ["number", "null"], "minimum": 0 }
+                }
+              },
+              "input_modalities": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": { "enum": ["text", "image", "video"] }
+              },
+              "thinking": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": { "enum": ["adaptive", "disabled", "always_on"] }
+              }
+            }
+          }
         }
       }
     },

--- a/src-tauri/providers/minimax-openai.yaml
+++ b/src-tauri/providers/minimax-openai.yaml
@@ -1,0 +1,65 @@
+id: minimax_openai
+display_name: "MiniMax (Chat Completions)"
+icon: minimax
+category: first_party
+description: "MiniMax M3 and M2 series Chat Completions-compatible endpoints"
+homepage: "https://platform.minimax.io"
+docs_url: "https://platform.minimax.io/docs"
+api_key_url: "https://platform.minimax.io/user-center/basic-information/interface-key"
+
+compatibility: untested
+compatibility_notes: "Uses the built-in protocol conversion path; model selection is manual because no public model-list endpoint is available."
+
+endpoints:
+  - id: global_chat_completions
+    label: "Global Chat Completions API"
+    description: "Global pay-as-you-go endpoint"
+    base_url: "https://api.minimax.io/v1"
+    messages_path: "/chat/completions"
+    region: global
+    billing: pay_as_you_go
+
+  - id: china_chat_completions
+    label: "China Chat Completions API"
+    description: "China pay-as-you-go endpoint"
+    base_url: "https://api.minimaxi.com/v1"
+    messages_path: "/chat/completions"
+    region: china
+    billing: pay_as_you_go
+
+default_endpoint: global_chat_completions
+
+auth:
+  type: openai_chat_completions_api_key
+  header_name: "Authorization"
+  header_format: bearer
+
+required_headers: {}
+forward_headers: []
+
+model_discovery:
+  enabled: false
+  path: "/v1/models"
+  cache_ttl_hours: 24
+  example_models:
+    - "MiniMax-M3"
+    - "MiniMax-M2.7"
+  model_metadata:
+    - model_id: "MiniMax-M3"
+      context_window: 1000000
+      pricing_usd_per_million_tokens:
+        input: 0.6
+        output: 2.4
+        cache_read: 0.12
+        cache_write: null
+      input_modalities: [text, image, video]
+      thinking: [adaptive, disabled]
+    - model_id: "MiniMax-M2.7"
+      context_window: 204800
+      pricing_usd_per_million_tokens:
+        input: 0.3
+        output: 1.2
+        cache_read: 0.06
+        cache_write: 0.375
+      input_modalities: [text]
+      thinking: [always_on]

--- a/src-tauri/providers/minimax.yaml
+++ b/src-tauri/providers/minimax.yaml
@@ -8,7 +8,7 @@ docs_url: "https://platform.minimax.io/docs"
 api_key_url: "https://platform.minimax.io/user-center/basic-information/interface-key"
 
 compatibility: untested
-compatibility_notes: 
+compatibility_notes: "Native endpoint configuration; model selection is manual because no public model-list endpoint is available."
 
 endpoints:
   - id: china_coding_plan
@@ -70,3 +70,22 @@ model_discovery:
     - "MiniMax-M2.1"
     - "MiniMax-M2.1-highspeed"
     - "MiniMax-M2"
+  model_metadata:
+    - model_id: "MiniMax-M3"
+      context_window: 1000000
+      pricing_usd_per_million_tokens:
+        input: 0.6
+        output: 2.4
+        cache_read: 0.12
+        cache_write: null
+      input_modalities: [text, image, video]
+      thinking: [adaptive, disabled]
+    - model_id: "MiniMax-M2.7"
+      context_window: 204800
+      pricing_usd_per_million_tokens:
+        input: 0.3
+        output: 1.2
+        cache_read: 0.06
+        cache_write: 0.375
+      input_modalities: [text]
+      thinking: [always_on]

--- a/src-tauri/src/provider/model.rs
+++ b/src-tauri/src/provider/model.rs
@@ -183,6 +183,29 @@ pub struct ModelDiscovery {
     pub cache_ttl_hours: u32,
     #[serde(default)]
     pub example_models: Vec<String>,
+    #[serde(default)]
+    pub model_metadata: Vec<ModelMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelPricing {
+    pub input: f64,
+    pub output: f64,
+    #[serde(default)]
+    pub cache_read: Option<f64>,
+    #[serde(default)]
+    pub cache_write: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelMetadata {
+    pub model_id: String,
+    pub context_window: u64,
+    pub pricing_usd_per_million_tokens: ModelPricing,
+    #[serde(default)]
+    pub input_modalities: Vec<String>,
+    #[serde(default)]
+    pub thinking: Vec<String>,
 }
 
 fn default_true() -> bool {
@@ -318,5 +341,54 @@ pub struct Provider {
 impl Provider {
     pub fn endpoint(&self, id: &str) -> Option<&ProviderEndpoint> {
         self.endpoints.iter().find(|e| e.id == id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Provider;
+
+    fn parse_and_validate_provider(yaml: &str) -> Provider {
+        let yaml_value: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let json_value = serde_json::to_value(&yaml_value).unwrap();
+        let schema_value: serde_json::Value =
+            serde_json::from_str(include_str!("../../providers/_schema.json")).unwrap();
+        let schema = jsonschema::JSONSchema::compile(&schema_value).unwrap();
+        assert!(schema.is_valid(&json_value));
+        serde_yaml::from_value(yaml_value).unwrap()
+    }
+
+    #[test]
+    fn parses_minimax_model_metadata() {
+        let provider = parse_and_validate_provider(include_str!("../../providers/minimax.yaml"));
+        let models = &provider.model_discovery.model_metadata;
+
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].model_id, "MiniMax-M3");
+        assert_eq!(models[0].context_window, 1_000_000);
+        assert_eq!(models[0].pricing_usd_per_million_tokens.input, 0.6);
+        assert_eq!(models[0].input_modalities, ["text", "image", "video"]);
+        assert_eq!(models[0].thinking, ["adaptive", "disabled"]);
+
+        assert_eq!(models[1].model_id, "MiniMax-M2.7");
+        assert_eq!(models[1].context_window, 204_800);
+        assert_eq!(models[1].pricing_usd_per_million_tokens.output, 1.2);
+        assert_eq!(models[1].thinking, ["always_on"]);
+    }
+
+    #[test]
+    fn parses_minimax_compatible_endpoints() {
+        let provider =
+            parse_and_validate_provider(include_str!("../../providers/minimax-openai.yaml"));
+
+        assert_eq!(provider.endpoints.len(), 2);
+        assert_eq!(
+            provider.endpoints[0].messages_url(),
+            "https://api.minimax.io/v1/chat/completions"
+        );
+        assert_eq!(
+            provider.endpoints[1].messages_url(),
+            "https://api.minimaxi.com/v1/chat/completions"
+        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,6 +53,7 @@
       "providers/deepseek.yaml",
       "providers/moonshot.yaml",
       "providers/minimax.yaml",
+      "providers/minimax-openai.yaml",
       "providers/xiaomi.yaml",
       "providers/alibaba.yaml",
       "providers/volcengine.yaml",

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,18 @@ export interface ProviderInfo {
     path: string;
     cache_ttl_hours: number;
     example_models: string[];
+    model_metadata: Array<{
+      model_id: string;
+      context_window: number;
+      pricing_usd_per_million_tokens: {
+        input: number;
+        output: number;
+        cache_read: number | null;
+        cache_write: number | null;
+      };
+      input_modalities: string[];
+      thinking: string[];
+    }>;
   };
 }
 


### PR DESCRIPTION
Reason: Refresh MiniMax model capability metadata and regional compatible endpoints.

## Changes

- Add typed context-window, pricing, input-modality, and thinking metadata for MiniMax-M3 and MiniMax-M2.7.
- Restore the global and China Chat Completions-compatible provider endpoints while leaving the native endpoints unchanged.
- Validate both descriptors against the provider schema and cover their metadata and resolved URLs with focused tests.

## Checks

- `rustfmt --edition 2021 --check src-tauri/src/provider/model.rs`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib provider::model::tests`
- `./node_modules/.bin/tsc --noEmit`
